### PR TITLE
Restrict default select to the 'entries' sub-query.

### DIFF
--- a/lib/report/sql_statement.rb
+++ b/lib/report/sql_statement.rb
@@ -154,7 +154,7 @@ class Report::SqlStatement
 
   def default_select(value = nil)
     @default_select = value if value
-    @default_select ||= ["*"]
+    @default_select ||= ["entries.*"]
   end
 
   ##


### PR DESCRIPTION
Some filters require additional joins to be added to the report query. With the default
'*' selection, columns from these additional joins would appear in the result set,
creating obscure bugs in case of column name clashes..

https://www.openproject.org/issues/2209
