### PR TITLE
do not double escape units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+* `#1020` fix XSS when displaying costs
+
 ## 0.0.1.pre6
 
 * fix minor css alignment issue

--- a/lib/widget/table/report_table.rb
+++ b/lib/widget/table/report_table.rb
@@ -116,7 +116,7 @@ class Widget::Table::ReportTable < Widget::Table
         opts = { :colspan => column.final_number(:column) }
         opts.merge!(:class => "inner") if first
         write(content_tag(:th, opts) do
-          "#{show_result(column)}" #{debug_fields(column)}
+          show_result(column) #{debug_fields(column)}
         end)
       end
       if last_in_col


### PR DESCRIPTION
Part2 of "fix xss in reporting when displaying costs"
https://www.openproject.org/issues/1020
