### PR TITLE
Meets #7505: HTML/scripts are not escaped when renaming cost reports

### DIFF
--- a/lib/assets/javascripts/reporting_engine/reporting/controls.js
+++ b/lib/assets/javascripts/reporting_engine/reporting/controls.js
@@ -63,6 +63,11 @@ Reporting.Controls = {
       onFailure: function (editor, response) {
         Reporting.flash(response.responseText);
       },
+      ajaxOptions: {
+        onSuccess: function (xhr) {
+            xhr.responseText = OpenProject.Helpers.markupEscape(xhr.responseText);
+        }
+      },
       onComplete: function () {
         Reporting.Controls.update_report_lists();
       }
@@ -207,5 +212,3 @@ Reporting.onload(function () {
   Reporting.Controls.attach_settings_callback($("query-icon-apply-button"), Reporting.Controls.update_result_table);
   Reporting.Controls.observe_click($('query-link-clear'), Reporting.Controls.clear_query);
 });
-
-


### PR DESCRIPTION
[`* `#7505` HTML/scripts are not escaped when renaming cost reports`](https://www.openproject.org/work_packages/7505)
