### PR TITLE
fix "group by" styles in cost reports

### DIFF
--- a/lib/assets/stylesheets/reporting_engine/reporting.css.erb
+++ b/lib/assets/stylesheets/reporting_engine/reporting.css.erb
@@ -251,8 +251,8 @@ fieldset.collapsible.header_collapsible legend.in_row {
   font-weight: bold;
   color: #fff;
   background-color: #9A9A9A;
-  height: 22px;
-  line-height: 22px;
+  height: 35px;
+  line-height: 35px;
   cursor: move;
 }
 
@@ -265,7 +265,7 @@ fieldset.collapsible.header_collapsible legend.in_row {
   height: 7px;
   width: 8px;
   position: absolute;
-  top: 2px;
+  top: 8px;
   right: 21px;
   cursor: pointer;
 }
@@ -291,8 +291,8 @@ h3.reporting_formatting {
   font-weight: bold;
   padding: 0 7px;
   margin: 0;
-  height: 22px;
-  line-height: 22px;
+  height: 35px;
+  line-height: 35px;
   min-width: 55px;
 }
 
@@ -300,7 +300,7 @@ h3.reporting_formatting {
   height: 0;
   width: 0;
   border-style: solid;
-  border-width: 11px 11px 11px 7px;
+  border-width: 18px 11px 17px 9px;
 }
 
 .arrow_left {
@@ -325,7 +325,7 @@ h3.reporting_formatting {
 
 .drag_container {
   padding: 0;
-  height: 22px;
+  height: 36px;
   margin-bottom: 1em;
   background-color: #EEE;
 }


### PR DESCRIPTION
fix "group by" styles in cost reports
before
![screenshot from 2015-04-29 14 51 14](https://cloud.githubusercontent.com/assets/9974302/7391012/1dfa39bc-ee86-11e4-87cd-e230e4cf5e27.png)

after
![screenshot from 2015-04-29 15 40 26](https://cloud.githubusercontent.com/assets/9974302/7391011/1df9f812-ee86-11e4-8b53-92d1b1098fea.png)
