### PR TITLE
Use jQuery instead of prototype to properly serialize multi value arrays

### DIFF
--- a/lib/assets/javascripts/reporting_engine/reporting/controls.js
+++ b/lib/assets/javascripts/reporting_engine/reporting/controls.js
@@ -83,7 +83,9 @@ Reporting.Controls = {
 
   serialize_settings_form: function() {
     var ret_str, grouping_str;
-    ret_str = Form.serialize('query_form');
+    // prototype has a bug when trying to serialize arrays with multiple values, hence jQuery
+    // see https://prototype.lighthouseapp.com/projects/8886/tickets/1180-formserialize-is-broken-for-multiple-selects
+    ret_str = jQuery('#query_form').serialize();
     grouping_str = $w('rows columns').inject('', function(grouping, type) {
       return grouping + $('group_by_' + type).select('.group_by_element').map(function(group_by) {
         return 'groups[' + type + '][]=' + group_by.readAttribute('data-group-by');


### PR DESCRIPTION
This PR aims to fix the serialization of multiselects. Prototype has a bug which results in the multiple values being serialized as one.

Alternatives to this fix are:
- Fork prototype-rails and fix it using https://prototype.lighthouseapp.com/projects/8886/tickets/1180-formserialize-is-broken-for-multiple-selects
- Replace prototype (probably with jQuery)

Kudos to @NobodysNightmare and @ulferts  for suggesting to use jQuery

https://community.openproject.org/work_packages/20843
