### PR TITLE
Remove custom String#write method which caused errors

### DIFF
--- a/lib/widget.rb
+++ b/lib/widget.rb
@@ -63,9 +63,3 @@ end
 
 ActionView::Base.send(:include, Widget::RenderWidgetInstanceMethods)
 ActionController::Base.send(:include, Widget::RenderWidgetInstanceMethods)
-
-class ::String
-  def write(s)
-    concat(s)
-  end
-end

--- a/lib/widget/base.rb
+++ b/lib/widget/base.rb
@@ -48,8 +48,8 @@ class Widget::Base < Widget
     str ||= ''
     @output ||= ''.html_safe
     @output = @output + '' if @output.frozen? # Rails 2 freezes tag strings
-    @output.write str.html_safe
-    @cache_output.write(str.html_safe) if @cache_output
+    @output.concat str.html_safe
+    @cache_output.concat(str.html_safe) if @cache_output
     str.html_safe
   end
 


### PR DESCRIPTION
parallel_test gem uses Io#write method to distinguish between string or
io input. Having this custom write method around broke the implementation
thus testsuite exit with wrong state (false positive).

Now using `concat` directly.

See https://github.com/grosser/parallel_tests/blob/master/lib/parallel_tests/gherkin/io.rb#L8
for the respective code in parallel_test.

This fixes the "undefined method puts for 'tmp/cucumber-rerun.txt'#String" error.
