### PR TITLE
Re-instate javascript translations

### DIFF
--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -25,7 +25,3 @@ da:
   units: Enheder
   validation_failure_date: er en ugyldig dato
   validation_failure_integer: er et ugyldigt heltal
-  js:
-    reporting_engine:
-      label_remove: Slet
-      label_response_error: En fejl opstod under forespørgselshåndtering.

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -25,7 +25,3 @@ de:
   units: Einheiten
   validation_failure_date: ist kein gültiges Datum
   validation_failure_integer: ist keine ganze Zahl
-  js:
-    reporting_engine:
-      label_remove: Lösche
-      label_response_error: Bei der Bearbeitung der Anfrage ist ein Fehler aufgetreten.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,8 +48,3 @@ en:
 
   validation_failure_date: "is not a valid date"
   validation_failure_integer: "is not a valid integer"
-
-  js:
-    reporting_engine:
-      label_remove: "Delete"
-      label_response_error: "There was an error handling the query."

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -26,7 +26,3 @@ fr:
   units: Unités
   validation_failure_date: "n'est pas une date valide"
   validation_failure_integer: "n'est pas un nombre entier valide"
-  js:
-    reporting_engine:
-      label_remove: Supprimer
-      label_response_error: "Une erreur s'est produite lors du traitement de la requête."

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -25,7 +25,3 @@ it:
   units: Unità di misura
   validation_failure_date: non è una data valida
   validation_failure_integer: non è un numero intero valido
-  js:
-    reporting_engine:
-      label_remove: Cancella
-      label_response_error: "C'era un errore di gestione query."

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -25,7 +25,3 @@ ja:
   units: 単位
   validation_failure_date: は有効な日付ではありません。
   validation_failure_integer: は有効な整数ではありません。
-  js:
-    reporting_engine:
-      label_remove: 削除
-      label_response_error: クエリの処理中にエラーが発生しました。

--- a/config/locales/js-da.yml
+++ b/config/locales/js-da.yml
@@ -1,0 +1,5 @@
+da:
+  js:
+    reporting_engine:
+      label_remove: Slet
+      label_response_error: En fejl opstod under forespørgselshåndtering.

--- a/config/locales/js-de.yml
+++ b/config/locales/js-de.yml
@@ -1,0 +1,5 @@
+de:
+  js:
+    reporting_engine:
+      label_remove: Lösche
+      label_response_error: Bei der Bearbeitung der Anfrage ist ein Fehler aufgetreten.

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -1,0 +1,23 @@
+#-- copyright
+# ReportingEngine
+#
+# Copyright (C) 2010 - 2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#++
+en:
+  js:
+    reporting_engine:
+      label_remove: "Delete"
+      label_response_error: "There was an error handling the query."

--- a/config/locales/js-fr.yml
+++ b/config/locales/js-fr.yml
@@ -1,0 +1,5 @@
+fr:
+  js:
+    reporting_engine:
+      label_remove: Supprimer
+      label_response_error: "Une erreur s'est produite lors du traitement de la requête."

--- a/config/locales/js-it.yml
+++ b/config/locales/js-it.yml
@@ -1,0 +1,5 @@
+it:
+  js:
+    reporting_engine:
+      label_remove: Cancella
+      label_response_error: "C'era un errore di gestione query."

--- a/config/locales/js-ja.yml
+++ b/config/locales/js-ja.yml
@@ -1,0 +1,5 @@
+ja:
+  js:
+    reporting_engine:
+      label_remove: 削除
+      label_response_error: クエリの処理中にエラーが発生しました。

--- a/config/locales/js-pt-BR.yml
+++ b/config/locales/js-pt-BR.yml
@@ -1,0 +1,5 @@
+pt-BR:
+  js:
+    reporting_engine:
+      label_remove: Excluir
+      label_response_error: Ocorreu um erro na manipulação da consulta.

--- a/config/locales/js-ru.yml
+++ b/config/locales/js-ru.yml
@@ -1,0 +1,5 @@
+ru:
+  js:
+    reporting_engine:
+      label_remove: Удалить
+      label_response_error: Произошла ошибка при обработке запроса.

--- a/config/locales/js-sk.yml
+++ b/config/locales/js-sk.yml
@@ -1,0 +1,5 @@
+sk:
+  js:
+    reporting_engine:
+      label_remove: Odstrániť
+      label_response_error: Počas spracovania dotazu sa vyskytla chyba.

--- a/config/locales/js-sv-SE.yml
+++ b/config/locales/js-sv-SE.yml
@@ -1,0 +1,5 @@
+sv:
+  js:
+    reporting_engine:
+      label_remove: Ta bort
+      label_response_error: Det uppstod ett fel när frågan hanterades.

--- a/config/locales/js-tr.yml
+++ b/config/locales/js-tr.yml
@@ -1,0 +1,5 @@
+tr:
+  js:
+    reporting_engine:
+      label_remove: Sil
+      label_response_error: Sorgu işleme sırasında bir hata oluştu.

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -25,7 +25,3 @@ ru:
   units: Модули
   validation_failure_date: не является допустимой датой
   validation_failure_integer: не является допустимым целым числом
-  js:
-    reporting_engine:
-      label_remove: Удалить
-      label_response_error: Произошла ошибка при обработке запроса.

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -25,7 +25,3 @@ sk:
   units: Jednotky
   validation_failure_date: nie je platný dátum
   validation_failure_integer: nie je platné celé číslo
-  js:
-    reporting_engine:
-      label_remove: Odstrániť
-      label_response_error: Počas spracovania dotazu sa vyskytla chyba.

--- a/config/locales/sv-SE.yml
+++ b/config/locales/sv-SE.yml
@@ -25,7 +25,3 @@ sv:
   units: Enheter
   validation_failure_date: inte är ett giltigt datum
   validation_failure_integer: är inte ett giltigt heltal
-  js:
-    reporting_engine:
-      label_remove: Ta bort
-      label_response_error: Det uppstod ett fel när frågan hanterades.

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -25,7 +25,3 @@ tr:
   units: Birimler
   validation_failure_date: geçerli bir tarih değil
   validation_failure_integer: geçerli bir tamsayı değil
-  js:
-    reporting_engine:
-      label_remove: Sil
-      label_response_error: Sorgu işleme sırasında bir hata oluştu.

--- a/frontend/app/reporting_engine-app.js
+++ b/frontend/app/reporting_engine-app.js
@@ -1,0 +1,34 @@
+//-- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+//++
+
+// load all js locales
+var localeFiles = require.context('../../config/locales', false, /js-[\w|-]{2,5}\.yml$/);
+localeFiles.keys().forEach(function(localeFile) {
+  var locale = localeFile.match(/js-([\w|-]{2,5})\.yml/)[1];
+  I18n.addTranslations(locale, localeFiles(localeFile)[locale]);
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "reporting_engine",
+  "version": "0.1.0",
+  "main": "frontend/app/reporting_engine-app.js",
+  "dependencies": {}
+}


### PR DESCRIPTION
JavaScript translations were lost since the transition to webpack, I presume.
