### PR TITLE
Use label instead of internal key

### DIFF
--- a/lib/widget/filters/text_box.rb
+++ b/lib/widget/filters/text_box.rb
@@ -23,7 +23,7 @@ require_dependency 'widget/filters/base'
 class Widget::Filters::TextBox < Widget::Filters::Base
   def render
     label = content_tag :label,
-                        h(l(filter_class.underscore_name)) + ' ' + l(:label_filter_value),
+                        "#{h(filter_class.label)} #{l(:label_filter_value)}",
                         for: "#{filter_class.underscore_name}_arg_1_val",
                         class: 'hidden-for-sighted'
 


### PR DESCRIPTION
The translation was invalid for many attributes, such as subject
or custom fields, where the string `customfieldN` was used instead of
the label of the field.

https://community.openproject.org/work_packages/20405/activity
