### PR TITLE
[22313] Arrow does not change when toggling fieldset

### DIFF
--- a/lib/widget/settings/fieldset.rb
+++ b/lib/widget/settings/fieldset.rb
@@ -31,7 +31,7 @@ class Widget::Settings::Fieldset < Widget::Base
     hash = self.hash
     write(content_tag(:fieldset,
                       id: @id,
-                      class: 'form--fieldset -collapsible -collapsed') do
+                      class: 'form--fieldset -collapsible') do
             html = content_tag(:legend,
                                show_at_id: hash.to_s,
                                icon: "#{@type}-legend-icon",


### PR DESCRIPTION
This removes the incorrect class which was responsible for the wrong arrow.

https://community.openproject.org/work_packages/22313/activity
