### PR TITLE
fix sorting the first colum

### DIFF
--- a/vendor/assets/javascripts/reporting_engine/sortable.js
+++ b/vendor/assets/javascripts/reporting_engine/sortable.js
@@ -198,7 +198,7 @@ function trim(s) {
 function ts_resortTable(lnk, clid) {
 	var td, column, t, first, itm, i, j, k, numeric_flag, all_sort_links, ci, firstRow, newRows, sortfn;
 	td = lnk.parentNode;
-	column = clid || td.cellIndex;
+	column = (clid === undefined ? td.cellIndex : clid);
 	t = getParent(td, 'TABLE');
 
 	// Do not sort single a row


### PR DESCRIPTION
In js: 0 == false => true. Therefore, when the column id was 0 the undefined second value was used.

https://community.openproject.org/work_packages/22317/activity
