### PR TITLE
Fix inverted row/column wrapping

### DIFF
--- a/lib/report/controller.rb
+++ b/lib/report/controller.rb
@@ -286,8 +286,8 @@ module Report::Controller
         end
       end
     end
-    groups[:rows].try(:reverse_each) { |r| query.row(r) }
     groups[:columns].try(:reverse_each) { |c| query.column(c) }
+    groups[:rows].try(:reverse_each) { |r| query.row(r) }
     query
   end
 


### PR DESCRIPTION
In production, wrapping rows first will lead to the outmost layer being
a column, which will cause the table widget rendered to skip rendering
content, why the f*ck ever that is.

https://community.openproject.org/work_packages/22762/activity
