### PR TITLE
[22906] Misaligned input fields in filters

### DIFF
--- a/lib/widget/filters/multi_values.rb
+++ b/lib/widget/filters/multi_values.rb
@@ -28,7 +28,7 @@ class Widget::Filters::MultiValues < Widget::Filters::Base
                           name: "values[#{filter_class.underscore_name}][]",
                           :"data-loading" => @options[:lazy] ? 'ajax' : '',
                           id: "#{filter_class.underscore_name}_arg_1_val",
-                          class: 'advanced-filters--select filter-value',
+                          class: 'form--select filter-value',
                           :"data-filter-name" => filter_class.underscore_name,
                           multiple: 'multiple' }
       # multiple will be disabled/enabled later by JavaScript anyhow.


### PR DESCRIPTION
This changes the used class to avoid a too long field like it is done in WP filters.

https://community.openproject.com/work_packages/22906/activity
