### PR TITLE
[20397] [Accessibility] Navigating through the entries of some drop down lists causes a page update (reporting engine)

### DIFF
--- a/lib/assets/javascripts/reporting_engine/reporting/filters.js
+++ b/lib/assets/javascripts/reporting_engine/reporting/filters.js
@@ -497,7 +497,11 @@ Reporting.onload(function () {
     $("add_filter_select").observe("change", function () {
       if (!(Reporting.Filters.exists(this.value))) {
         Reporting.Filters.add_filter(this.value);
+        var new_filter = this.value;
         this.selectedIndex = 0;
+        setTimeout(function () {
+          $(document).getElementById('operators['+ new_filter +']').focus();
+        }, 300);
       };
     });
   }

--- a/lib/widget/filters.rb
+++ b/lib/widget/filters.rb
@@ -24,6 +24,9 @@ class Widget::Filters < Widget::Base
     add_filter = content_tag :li, id: 'add_filter_block', class: 'advanced-filters--add-filter' do
       add_filter_label = label_tag 'add_filter_select', l(:label_filter_add),
                                    class: 'advanced-filters--add-filter-label'
+      add_filter_label += label_tag 'add_filter_select', I18n.t('js.filter.description.text_open_filter') + ' ' +
+                                   I18n.t('js.filter.description.text_close_filter'),
+                                   class: 'hidden-for-sighted'
 
       add_filter_value = content_tag :div, class: 'advanced-filters--add-filter-value' do
         value = select_tag 'add_filter_select',

--- a/lib/widget/filters/operators.rb
+++ b/lib/widget/filters/operators.rb
@@ -39,7 +39,7 @@ class Widget::Filters::Operators < Widget::Filters::Base
         end.join.html_safe
       end
       label1 = content_tag :label,
-                           h(filter_class.label) + ' ' + l(:label_operator),
+                           h(filter_class.label) + ' ' + l(:label_operator) + ' ' + I18n.t('js.filter.description.text_open_filter'),
                            for: "operators[#{filter_class.underscore_name}]",
                            class: 'hidden-for-sighted'
       label = content_tag :label do


### PR DESCRIPTION
This adds a helping text to the filter in cost reports which updates automatically after selecting a filter. Further the focus is set on the newly added filter.

_Note_ This works only in combination with https://github.com/opf/openproject/pull/4295 since the used text description is introduced there.

https://community.openproject.com/work_packages/20397/activity
