### PR TITLE
[23504] [2u] Inhalte aufgrund von Sonderzeichen schwer wahrnehmbar (Reporting Engine)

### DIFF
--- a/lib/widget/group_bys.rb
+++ b/lib/widget/group_bys.rb
@@ -54,7 +54,7 @@ class Widget::GroupBys < Widget::Base
                        class: 'hidden-for-sighted'
 
       out += content_tag :select, id: "add_group_by_#{type}", class: 'advanced-filters--select' do
-        content = content_tag :option, "-- #{l(:label_group_by_add)} --", value: ''
+        content = content_tag :option, l(:label_group_by_add), value: ''
 
         content += engine::GroupBy.all_grouped.sort_by do |label, _group_by_ary|
           l(label)


### PR DESCRIPTION
This removes special characters from filter elements which were only used for styling issues. Blind users were confused by these characters.

https://community.openproject.com/work_packages/23504/activity

Related PRs:
- https://github.com/opf/openproject/pull/4722
- https://github.com/finnlabs/openproject-reporting/pull/106
