### PR TITLE
[23438] [1o] Ausklapplisten können nicht im geschlossenen Zustand bedient werden (Reporting)

### DIFF
--- a/lib/widget/group_bys.rb
+++ b/lib/widget/group_bys.rb
@@ -50,7 +50,8 @@ class Widget::GroupBys < Widget::Base
       out += render_group_caption type
 
       out += label_tag "add_group_by_#{type}",
-                       l(:"label_group_by_add"),
+                       l(:"label_group_by_add") + ' ' +
+                       I18n.t('js.filter.description.text_open_filter'),
                        class: 'hidden-for-sighted'
 
       out += content_tag :select, id: "add_group_by_#{type}", class: 'advanced-filters--select' do


### PR DESCRIPTION
This adds a hint text for the group by-select box. Thus blind users know how to open it without triggering the refresh. The problem itself only occurs in IE.

Related Core PR: https://github.com/opf/openproject/pull/4761

https://community.openproject.com/work_packages/23438/activity
