### PR TITLE
[23455] [4c] Fokusverlust an den Seitenanfang nach dem Registerkartenwechsel (Reporting Engine)

### DIFF
--- a/lib/assets/javascripts/reporting_engine/reporting/filters.js
+++ b/lib/assets/javascripts/reporting_engine/reporting/filters.js
@@ -515,8 +515,13 @@ Reporting.onload(function () {
       if (event.keyCode == 13 || event.keyCode == 32) {
         Event.stop(event);
         var filter_name = this.up('li').getAttribute("data-filter-name");
+        var prevVisibleFilter = jQuery('li.advanced-filters--filter#filter_'+filter_name).prevUntil(':visible').prev().last().find('.advanced-filters--select');
+        if (prevVisibleFilter.length != 0) {
+          prevVisibleFilter.focus();
+        } else {
+          $$('#filters > legend a')[0].focus();
+        }
         Reporting.Filters.remove_filter(filter_name);
-        $$('#filters > legend a')[0].focus();
       }
     });
   });


### PR DESCRIPTION
This sets the focus to the previous filter when a filter is removed. When the filter is the first, the focus is set to the legend.

Related PR: https://github.com/opf/openproject/pull/4815

https://community.openproject.com/work_packages/23455/activity
