### PR TITLE
Sort specific keys as integers

### DIFF
--- a/lib/report/query_utils.rb
+++ b/lib/report/query_utils.rb
@@ -226,6 +226,7 @@ module Report::QueryUtils
   def map_field(key, value)
     case key.to_s
     when 'singleton_value', /_id$/ then convert_unless_nil(value) { |v| v.to_i }
+    when 'work_package_id', 'tweek', 'tmonth', 'tweek' then value.to_i
     else convert_unless_nil(value) { |v| v.to_s }
     end
   end


### PR DESCRIPTION
This is actually logic from reporting, but there's no way to discover
which keys are used to fix the sorting.
