### PR TITLE
[24001] Wrong icon color in cost reports filter

### DIFF
--- a/lib/assets/stylesheets/reporting_engine/reporting.css.erb
+++ b/lib/assets/stylesheets/reporting_engine/reporting.css.erb
@@ -282,10 +282,13 @@ fieldset.collapsible.header_collapsible legend.in_row {
 .group-by--remove {
   line-height: 36px;
   cursor: pointer;
+  color: #FFFFFF;
 }
 
 .group-by--remove:hover {
   background-color: #3493B3 !important;
+  text-decoration: none;
+  color: #FFFFFF;
 }
 
 .group-by--control {


### PR DESCRIPTION
This changes the icon color of the remove icon. Thus it is better to be seen.

https://community.openproject.com/work_packages/24001/activity
