### PR TITLE
[25672] Cost report table looks broken when grouped only by row

### DIFF
--- a/lib/assets/stylesheets/reporting_engine/reporting.css.erb
+++ b/lib/assets/stylesheets/reporting_engine/reporting.css.erb
@@ -71,8 +71,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   font-size: 0.875rem;
   line-height: 34px;
   padding: 0 8px 0 8px;
-
+  height: 34px;
 }
+
 
 .report .odd th.inner {
   background-color: #e8e8e8;


### PR DESCRIPTION
When a cost reports is only grouped by row the table header is empty. Thus the header row is not displayed which looks weird. This PR sets a height to avoid this. However the header is not limited to this height when more space is required.

https://community.openproject.com/projects/openproject/work_packages/25672/activity