### PR TITLE
fix grouping by row only

### DIFF
--- a/lib/report/group_by/base.rb
+++ b/lib/report/group_by/base.rb
@@ -24,7 +24,7 @@ class Report::GroupBy
     inherited_attributes :group_fields, list: true, merge: false
 
     def correct_position?
-      type == :row or !child.is_a?(engine::GroupBy::Base) or child.type == :column
+      type == :row or !child.is_a?(Report::GroupBy::Base) or child.type == :column
     end
 
     def filter?


### PR DESCRIPTION
When only having a depth of 0 in the chain of colums and rows, a
GroupBy, the Report::GroupBy::SingeltonValue is added. To properly
chain the GroupBy, the correct position is determined on adding a new
GroupBy to the chain. All GroupBys are supposed to be chained after one
another. This is done by bubbling the newly added element up in the
chain until the correct position is found. One of the parts of the check
for the correct position relies on the class of the child (and its
superclasses). The class compared against is engine::GroupBy::Base.
The engine-part is determined dynamically to allow for employing the
engine in various environments. For reasons unknown, the engine-part
resolves differently when in development mode (e.g. CostQuery)
compared to when in production mode (Report). This causes the chain to
be ordered differently as Report::GroupBy::SingletonValue is no
CostQuery::GroupBy::Base.

It should be save to compare to Report::GroupBy::Base all the time,
as even the engine specific GroupBys will inherit from that class.

https://community.openproject.com/projects/openproject/work_packages/25672